### PR TITLE
Update CNPJ input length error message to use characters

### DIFF
--- a/.changeset/clear-cnpj-length-message.md
+++ b/.changeset/clear-cnpj-length-message.md
@@ -1,0 +1,5 @@
+---
+"@lacussoft/cnpj-dv": minor
+---
+
+`CnpjCheckDigitsInputLengthException` now refers to "characters" instead of "digits" to match alphanumeric input support.

--- a/packages/cnpj-dv/src/exceptions.ts
+++ b/packages/cnpj-dv/src/exceptions.ts
@@ -100,7 +100,7 @@ export class CnpjCheckDigitsInputLengthException extends CnpjCheckDigitsExceptio
         : `${evaluatedInput.length} in "${evaluatedInput}"`;
 
     super(
-      `CNPJ input ${fmtActualInput} does not contain ${minExpectedLength} to ${maxExpectedLength} digits. Got ${fmtEvaluatedInput}.`,
+      `CNPJ input ${fmtActualInput} does not contain ${minExpectedLength} to ${maxExpectedLength} characters. Got ${fmtEvaluatedInput}.`,
     );
     this.actualInput = actualInput;
     this.evaluatedInput = evaluatedInput;

--- a/packages/cnpj-dv/tests/exceptions.spec.ts
+++ b/packages/cnpj-dv/tests/exceptions.spec.ts
@@ -186,7 +186,7 @@ describe('CnpjCheckDigitsInputLengthException', () => {
       const evaluatedInput = '12345';
       const minExpectedLength = 12;
       const maxExpectedLength = 14;
-      const actualMessage = `CNPJ input "${actualInput}" does not contain ${minExpectedLength} to ${maxExpectedLength} digits. Got ${evaluatedInput.length} in "${evaluatedInput}".`;
+      const actualMessage = `CNPJ input "${actualInput}" does not contain ${minExpectedLength} to ${maxExpectedLength} characters. Got ${evaluatedInput.length} in "${evaluatedInput}".`;
 
       const exception = new CnpjCheckDigitsInputLengthException(
         actualInput,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the CNPJ input length error message to refer to **characters** instead of **digits**, making the message accurate for alphanumeric input.
  * Aligned the related validation message in tests to match the updated wording.

* **Documentation**
  * Refreshed the changelog entry to reflect the revised error message wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->